### PR TITLE
Remove debug artefact

### DIFF
--- a/xmla/olap/xmla/connection.py
+++ b/xmla/olap/xmla/connection.py
@@ -123,7 +123,6 @@ class XMLAConnection(object):
             pl = {"PropertyList":properties}
             
         try:
-            import pdb; pdb.set_trace()
             doc=self.client.service.Discover(what, rl, pl)
             res = getattr(doc.DiscoverResponse["return"].root, "row", [])
             if res:


### PR DESCRIPTION
The problem was pointed out here: https://github.com/may-day/olap/commit/f8324e470e0ab2ebd64cdb2af62b24bf19c9c4cc

This is of some important as this debug statement completly breaks to production code.